### PR TITLE
Add flag to not create a powershell window on Windows

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,15 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    Command::new(shell)
+    let mut command = Command::new(shell);
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    command
         .args(args)
         .output()
         .map_err(MIDError::ExecuteProcessError)


### PR DESCRIPTION
When I use your package in Tauri.app. It automatically opens a powershell window to run the command.

So I added an option to prevent it from opening additional windows on Windows.

Can you help me check if this is possible?

Thank you!