### PR TITLE
Minimize external dependencies on Linux

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,5 +1,7 @@
 #[cfg(target_os = "linux")]
 use std::collections::HashSet;
+#[cfg(target_os = "linux")]
+use std::fs;
 
 #[cfg(target_os = "linux")]
 use crate::errors::MIDError;
@@ -9,15 +11,14 @@ use crate::utils::run_shell_command;
 
 #[cfg(target_os = "linux")]
 pub(crate) fn get_mid_result() -> Result<String, MIDError> {
-    let machine_output = run_shell_command(
-        "sh",
-        [
-            "-c",
-            r#"hostnamectl status | awk '/Machine ID:/ {print $3}'; cat /var/lib/dbus/machine-id || true; cat /etc/machine-id || true"#,
-        ],
-    )?;
+    let hostnamectl_status = run_shell_command("hostnamectl", ["status"])
+        .ok()
+        .and_then(parse_mid);
 
-    let combined_string = process_output(&machine_output);
+    let dbus_mid = fs::read_to_string("/var/lib/dbus/machine-id").ok();
+    let etc_mid = fs::read_to_string("/etc/machine-id").ok();
+
+    let combined_string = process_output([hostnamectl_status, dbus_mid, etc_mid]);
 
     if combined_string.is_empty() {
         return Err(MIDError::ResultMidError);
@@ -27,12 +28,12 @@ pub(crate) fn get_mid_result() -> Result<String, MIDError> {
 }
 
 #[cfg(target_os = "linux")]
-fn process_output(output_str: &str) -> String {
+fn process_output(output: [Option<String>; 3]) -> String {
     let mut md5_hashes = HashSet::new();
 
-    for line in output_str.to_lowercase().lines() {
-        if line.len() == 32 && line.chars().all(|c| c.is_ascii_hexdigit()) {
-            md5_hashes.insert(line.to_string());
+    for hash in output.into_iter().flatten() {
+        if hash.len() == 32 && hash.chars().all(|c| c.is_ascii_hexdigit()) {
+            md5_hashes.insert(hash);
         }
     }
 
@@ -43,4 +44,14 @@ fn process_output(output_str: &str) -> String {
         .join("|")
         .trim()
         .to_string()
+}
+
+#[cfg(target_os = "linux")]
+fn parse_mid(hostnamectl_status: String) -> Option<String> {
+    const PATTERN: &str = "Machine ID: ";
+
+    let pos = hostnamectl_status.find(PATTERN)?;
+    let after_pattern = hostnamectl_status.split_at(pos + PATTERN.len()).1;
+
+    Some(after_pattern.lines().next()?.to_owned())
 }


### PR DESCRIPTION
This PR does not change the output, I checked it by running the CI on my branch.
It would be great to minimize the use of external dependencies which are not necessary. The reason is on a system using SELinux, where you need a policy to allow the different actions of you program, the actual implementation on Linux makes you write a lot of rules to allow the execution of all the tools used.
With the refactor, you only need to allow execution of `hostnamectl` and read access on both files.